### PR TITLE
Desabilitar reacción (scale) de los íconos al hacer hover

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -98,9 +98,9 @@ i {
     width: 70px;
 }
 
-.circle:hover {
+/*.circle:hover {
     transform: scale(1.2);
-}
+} */
 
 #como .fa {
     font-size: 35px;


### PR DESCRIPTION
No son botones, no hay acciones para realizar, por lo tanto el ícono (circle) no debería modificarse al hacer hover sobre los mismos.
