### PR TITLE
Fix video controls

### DIFF
--- a/client/src/components/App/Home/styled.js
+++ b/client/src/components/App/Home/styled.js
@@ -64,6 +64,7 @@ const Content = styled.article`
     left: 0;
     right: 0;
     bottom: -140px;
+    z-index: 1;
 
     @media (min-width: 768px) {
       bottom: -80px;

--- a/client/src/components/App/Nav/styled.js
+++ b/client/src/components/App/Nav/styled.js
@@ -7,7 +7,7 @@ const StyledNav = styled.nav`
   font-weight: 500;
   color: var(--grey-5);
   background-color: white;
-  z-index: 1;
+  z-index: 2;
 
   &.scrolled {
     box-shadow: 0 3px 2px -2px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Fix para los botones que controlan el video.

No se podía acceder a los botones del video debido a que este se encontraba por debajo del contenido.

### Funcionamiento anterior:

![ScreenCast2](https://user-images.githubusercontent.com/21026384/55303292-97414c80-541b-11e9-84c3-1aee279130c0.gif)

### Funcionamiento actual:

![ScreenCast](https://user-images.githubusercontent.com/21026384/55303127-c6a38980-541a-11e9-9473-99f2f0a6cf26.gif)

