### PR TITLE
Update gatsby-config.js

### DIFF
--- a/client/gatsby-config.js
+++ b/client/gatsby-config.js
@@ -22,8 +22,8 @@ module.exports = {
         name: `gatsby-starter-default`,
         short_name: `starter`,
         start_url: `/`,
-        background_color: `#663399`,
-        theme_color: `#663399`,
+        background_color: `#58acdc`,
+        theme_color: `#58acdc`,
         display: `minimal-ui`,
         icon: `src/images/fccba-icon.png`, // This path is relative to the root of the site.
       },


### PR DESCRIPTION
The color displayed in the header bar is purple in Google Chrome Mobile (Android).
This fix should make the color consistent with the one we use.